### PR TITLE
Cleanup before v3.0 release

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,11 +15,13 @@ You can cite this repo as
   title = {Subwavelength Physics},
   author = {Barandun, Silvio and Uhlmann, Alexander},
   url = {https://github.com/silvioba/subwavelength-physics},
-  version = {v2.0}
+  version = {v3.0}
 }
 
-=== FMM
-@auhlmann developed a great idea on how to make the 3D code faster using the fast multiple method (FMM). We build this into the v2 of the code. FMM needs a good library to run, which python does not provide out of the box. Here below you find a step-by-step guide on how to get this to work. The indications are for linux/ubuntu shell, but it should not be too different on other devices.
+=== Optional dependencies
+
+==== FMM
+@auhlmann developed a great idea on how to make the 3D code faster using the fast multipole method (FMM). This was introduced in v2 and is still available in v3. FMM needs a good library to run, which python does not provide out of the box. Here below you find a step-by-step guide on how to get this to work. The indications are for linux/ubuntu shell, but it should not be too different on other devices.
 
 . Create a python3.11 virtual environment
 +
@@ -45,6 +47,16 @@ source venv/bin/activate
 
 . Now you need the python wrapper. To do this run `make python` from the same dir. You probably need also to run `sudo apt install python3.11-dev build-essential gfortran` before this step. Now you should be able to run `python python/test/test_hfmm.py`
 
+==== Epstein zeta (v3.0)
+`Subwavelength3D/epstein.py` provides a faster monopole-only quasiperiodic capacitance matrix via the Epstein zeta function. It requires the `epsteinlib` package:
+
+[source,shell]
+----
+pip install epsteinlib
+----
+
+If `epsteinlib` is not installed, importing `Subwavelength3D.epstein` raises an `ImportError` with installation instructions. All other 3D functionality is unaffected.
+
 === Project Structure
 ----
 .
@@ -64,14 +76,19 @@ source venv/bin/activate
 │   ├── swp.py
 │   └── time_modulated.py
 ├── Subwavelength3D                             # 3D code
-│   ├── classic_finite.py
-│   ├── classic_periodic.py
-│   ├── fmm.py
+│   ├── classic_finite.py                      # Classical finite systems (multipole expansion)
+│   ├── classic_periodic.py                    # Classical periodic systems (lattice sums)
+│   ├── nonreciprocal.py                       # Non-reciprocal finite and periodic systems (v3.0)
+│   ├── epstein.py                             # Epstein zeta acceleration (monopole, optional epsteinlib)
+│   ├── fmm.py                                 # Fast multipole method acceleration
 │   ├── swp.py
 │   └── theory.adoc
 ├── tests
 │   ├── test_3D_finite.py
 │   ├── test_3D_periodic.py
+│   ├── test_3D_nonreciprocal.py               # Tests for NonReciprocalFiniteSWP3D (v3.0)
+│   ├── test_3D_nonreciprocal_periodic.py      # Tests for NonReciprocalPeriodicSWP3D (v3.0)
+│   ├── test_3D_periodic_epstein.py            # Epstein zeta vs lattice sum consistency (v3.0)
 │   ├── test_classic.py
 │   ├── test_nonreciprocal.py
 │   └── test_utils.py

--- a/Subwavelength1D/M_matrix.py
+++ b/Subwavelength1D/M_matrix.py
@@ -1,3 +1,5 @@
+"""Banded matrix wrappers as SWP objects for direct capacitance matrix specification."""
+
 import numpy as np
 import scipy as sci
 from Subwavelength1D.swp import (
@@ -17,6 +19,12 @@ import copy
 # to extend all the logic from SWP1D to M-matrix systems.
 
 class FiniteBandedMMatrix(FiniteSWP1D):
+    """Wraps a banded matrix as a finite SWP object for eigenvalue analysis.
+
+    Args:
+        diagonals: List of arrays [main_diag, super_diag_1, ...]. Sub-diagonals are mirrored.
+    """
+
     def __init__(self, diagonals: List[np.ndarray]):
         self.diagonals = diagonals
         self.N = len(diagonals[0])
@@ -67,6 +75,8 @@ class FiniteBandedMMatrix(FiniteSWP1D):
 
 
 class PeriodicBandedMMatrix(PeriodicSWP1D):
+    """Wraps a banded matrix as a periodic SWP object with Bloch wave number dependence."""
+
     def __init__(self, diagonals: List[np.ndarray]):
         self.diagonals = diagonals
         self.N = len(diagonals[0])

--- a/Subwavelength1D/__init__.py
+++ b/Subwavelength1D/__init__.py
@@ -1,0 +1,13 @@
+"""One-dimensional subwavelength resonator systems."""
+
+from Subwavelength1D.classic import ClassicFiniteSWP1D, ClassicPeriodicSWP1D
+from Subwavelength1D.nonreciprocal import (
+    NonReciprocalFiniteSWP1D,
+    NonReciprocalPeriodicSWP1D,
+)
+from Subwavelength1D.disordered import (
+    DisorderedClassicFiniteSWP1D,
+    DisorderedNonReciprocalFiniteSWP1D,
+)
+from Subwavelength1D.time_modulated import TimeModulatedFiniteSWP1D
+from Subwavelength1D.M_matrix import FiniteBandedMMatrix, PeriodicBandedMMatrix

--- a/Subwavelength1D/classic.py
+++ b/Subwavelength1D/classic.py
@@ -1,3 +1,5 @@
+"""Classical (reciprocal) finite and periodic 1D subwavelength resonator systems."""
+
 import numpy as np
 import scipy as sci
 from Subwavelength1D.swp import (
@@ -31,14 +33,14 @@ def check_parameters_inconsistencies(fwp: FiniteSWP1D):
     if not (np.abs(fwp.k_in - fwp.omega / fwp.v_in) < 1e-6).all():
         raise ValueError("k_in does not equal omega / v_in")
     if not (np.abs(fwp.k_out - fwp.omega / fwp.v_out) < 1e-6).all():
-        raise ValueError("k_in does not equal omega / v_in")
+        raise ValueError("k_out does not equal omega / v_out")
 
 
 class ClassicFiniteSWP1D(FiniteSWP1D):
-    FiniteSWP1D.__doc__ + """
-    Base class for acoustic subwavelength wave problem. Subclass of OneDimensionalFiniteSWLProblem
+    """Classical finite 1D subwavelength resonator system.
 
-    Initially modelled on [1] (see README), subsequently extended
+    Extends FiniteSWP1D with reciprocal acoustic physics: capacitance matrix,
+    eigenvalue computation, propagation matrices, and wave solution methods.
     """
 
     def __init__(self, **pars):
@@ -400,12 +402,16 @@ class ClassicFiniteSWP1D(FiniteSWP1D):
         Q0 = utils_propagation.get_Q_matrix(self.k_out, 0)
         QL = utils_propagation.get_Q_matrix(self.k_out, self.L)
         M = np.linalg.inv(QL) @ pm @ Q0
-        print(M)
         Rtot = - M[1, 0] / M[1, 1]
         Ttot = M[0, 0] + M[0, 1] * Rtot
         return np.abs(Rtot), np.abs(Ttot)
 
     def solve_u(self, alpha_0=None):
+        """Compute the wave solution coefficients by propagating through all resonators.
+
+        Args:
+            alpha_0: Initial exterior coefficients [forward, backward]. Defaults to [0, 1].
+        """
         assert self.omega is not None, "omega must be set, is currently None"
 
         alphas = np.zeros((self.N + 1, 2), dtype=complex)
@@ -437,6 +443,15 @@ class ClassicFiniteSWP1D(FiniteSWP1D):
         self.aas = aas
 
     def u(self, x, return_inside=False):
+        """Evaluate the wave solution at position x.
+
+        Args:
+            x: Position at which to evaluate.
+            return_inside: If True, also return whether x is inside a resonator.
+
+        Returns:
+            Complex wave amplitude, or (amplitude, is_inside) if return_inside is True.
+        """
         assert self.aas is not None and self.alphas is not None, "Must call solve_u before calling u"
         # Find j such that self.xi[j] < x < self.xi[j+1]
         j = np.searchsorted(self.xi, x) - 1

--- a/Subwavelength1D/disordered.py
+++ b/Subwavelength1D/disordered.py
@@ -1,3 +1,5 @@
+"""Disordered 1D subwavelength systems built from random block sequences."""
+
 import numpy as np
 import scipy as sci
 
@@ -22,6 +24,8 @@ plt.rcParams.update(settings.matplotlib_params)
 
 
 class DisorderedCommon(FiniteSWP1D):
+    """Mixin providing block-based construction for disordered systems."""
+
     @classmethod
     def from_blocks(
         cls, blocks: List[Tuple[Tuple[int | float]]], idxs: List[int], **params

--- a/Subwavelength1D/exceptional_point.py
+++ b/Subwavelength1D/exceptional_point.py
@@ -1,3 +1,5 @@
+"""Systems with complex velocities near exceptional points."""
+
 import numpy as np
 import scipy as sci
 from scipy.linalg import null_space, pinv
@@ -22,6 +24,8 @@ from Utils.utils_general import *
 
 
 class EPArrayClassicFiniteSWP1D(ClassicFiniteSWP1D):
+    """Classical system with complex velocities parametrised near exceptional points."""
+
     def __init__(self, N_cells, ep_idx=0, eps=0, **kwargs):
         self.N_cells = N_cells
         self.ep_idx = ep_idx

--- a/Subwavelength1D/metaatom.py
+++ b/Subwavelength1D/metaatom.py
@@ -1,3 +1,5 @@
+"""Metaatom pattern parsing, spectrum computation, and splitting analysis."""
+
 import time
 import numpy as np
 from scipy.signal import correlate

--- a/Subwavelength1D/nonreciprocal.py
+++ b/Subwavelength1D/nonreciprocal.py
@@ -1,3 +1,5 @@
+"""Non-reciprocal finite and periodic 1D subwavelength resonator systems."""
+
 import numpy as np
 import scipy as sci
 from Subwavelength1D.swp import (
@@ -24,11 +26,11 @@ import Utils.utils_general as utils
 plt.rcParams.update(settings.matplotlib_params)
 
 
-def check_parameters_inconsitencies(fwp: FiniteSWP1D):
+def check_parameters_inconsistencies(fwp: FiniteSWP1D):
     if not (np.abs(fwp.k_in - fwp.omega / fwp.v_in) < 1e-6).all():
         raise ValueError("k_in does not equal omega / v_in")
     if not (np.abs(fwp.k_out - fwp.omega / fwp.v_out) < 1e-6).all():
-        raise ValueError("k_in does not equal omega / v_in")
+        raise ValueError("k_out does not equal omega / v_out")
 
 
 class NonReciprocalFiniteSWP1D(FiniteSWP1D):
@@ -56,7 +58,7 @@ class NonReciprocalFiniteSWP1D(FiniteSWP1D):
                 raise AttributeError(
                     f"{self.__class__.__name__} has no attribute '{key}'"
                 )
-        check_parameters_inconsitencies(self)
+        check_parameters_inconsistencies(self)
 
     def __get_capacitance_diagonal(self) -> np.ndarray:
         assert self.N > 1, "N must be greater than 1 to compute capacitance matrix"
@@ -288,6 +290,11 @@ class NonReciprocalFiniteSWP1D(FiniteSWP1D):
             return log_norm_sum/max_N - 1/(2 * max_N) * gamma_li_sum
 
     def solve_u(self, alpha_0=None):
+        """Compute the non-reciprocal wave solution coefficients.
+
+        Args:
+            alpha_0: Initial exterior coefficients [forward, backward]. Defaults to [0, 1].
+        """
         assert self.omega is not None, "omega must be set, is currently None"
 
         alphas = np.zeros((self.N + 1, 2), dtype=complex)
@@ -324,7 +331,7 @@ class NonReciprocalFiniteSWP1D(FiniteSWP1D):
         self.aas = aas
 
     def Gamma(self, x):
-        # Returns \int_0^x gamma(x') dx'
+        """Compute the integrated gauge potential from 0 to x: integral of gamma(x') dx'."""
         j = np.searchsorted(self.xi, x) - 1
         if j % 2 == 0:
             # Inside resonator
@@ -338,6 +345,15 @@ class NonReciprocalFiniteSWP1D(FiniteSWP1D):
             return np.sum(self.gammas[:i] * self.l[:i])
 
     def u(self, x, return_inside=False):
+        """Evaluate the non-reciprocal wave solution at position x.
+
+        Args:
+            x: Position at which to evaluate.
+            return_inside: If True, also return whether x is inside a resonator.
+
+        Returns:
+            Complex wave amplitude, or (amplitude, is_inside) if return_inside is True.
+        """
         assert self.aas is not None and self.alphas is not None, "Must call solve_u before calling u"
 
         def _Xi(gamma, omega):

--- a/Subwavelength1D/quasiperiodic.py
+++ b/Subwavelength1D/quasiperiodic.py
@@ -1,3 +1,5 @@
+"""Quasiperiodic sequence generators and analysis for 1D subwavelength systems."""
+
 import numpy as np
 from scipy.signal import correlate
 

--- a/Subwavelength1D/simulation.py
+++ b/Subwavelength1D/simulation.py
@@ -1,3 +1,5 @@
+"""FDTD simulation of the 1D acoustic wave equation in subwavelength structures."""
+
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/Subwavelength1D/swp.py
+++ b/Subwavelength1D/swp.py
@@ -1,3 +1,5 @@
+"""Base classes for one-dimensional subwavelength resonator systems."""
+
 import numpy as np
 import scipy as sci
 
@@ -7,7 +9,6 @@ from typing import Literal, Callable, Tuple, Self, List
 import Utils.utils_general as utils
 
 import matplotlib.pyplot as plt
-import Utils.settings as settings
 
 
 class SWP1D:
@@ -76,7 +77,7 @@ class SWP1D:
         if omega:
             self.set_omega(omega)
         else:
-            self.k_in, self.k_in = None, None
+            self.k_in, self.k_out = None, None
 
         self.uin = uin
         self.duin = duin

--- a/Subwavelength1D/time_modulated.py
+++ b/Subwavelength1D/time_modulated.py
@@ -1,3 +1,5 @@
+"""Time-modulated 1D subwavelength systems with Floquet-Bloch theory."""
+
 import numpy as np
 import scipy as sci
 from scipy.sparse.linalg import eigs

--- a/Subwavelength3D/__init__.py
+++ b/Subwavelength3D/__init__.py
@@ -1,0 +1,8 @@
+"""Three-dimensional subwavelength resonator systems (spherical resonators)."""
+
+from Subwavelength3D.classic_finite import ClassicFiniteSWP3D
+from Subwavelength3D.classic_periodic import ClassicPeriodicFWP3D
+from Subwavelength3D.nonreciprocal import (
+    NonReciprocalFiniteSWP3D,
+    NonReciprocalPeriodicSWP3D,
+)

--- a/Subwavelength3D/classic_finite.py
+++ b/Subwavelength3D/classic_finite.py
@@ -1,27 +1,17 @@
+"""Classical finite 3D subwavelength systems using multipole expansions."""
+
 import numpy as np
 import scipy as sci
 
-from mpmath import polylog
-from mpmath import mp
 from Subwavelength3D.swp import SWP3D
 import Subwavelength3D.fmm as fmm
-from Utils.settings import settings
 import Utils.utils_general as utils
 
-import matplotlib.pyplot as plt
-import matplotlib.colors as colors
-from matplotlib.colors import LinearSegmentedColormap, LogNorm
-
-from typing import Literal, Callable, Tuple, Self, List, Dict
+from typing import Literal, Tuple, Self
 from typing_extensions import override
 
 from scipy.special import spherical_jn, hankel1, sph_harm
 from sympy.physics.wigner import wigner_3j
-from scipy.linalg import block_diag
-
-from math import factorial
-
-from joblib import Parallel, delayed  # For parallelism
 
 from functools import cache
 
@@ -200,6 +190,7 @@ def S_coefficient_diagonal(l: int, m: int, k: float, Ri: float):
 
 
 class ClassicFiniteSWP3D(SWP3D):
+    """Classical finite 3D system of spherical resonators with multipole expansions."""
 
     def __init__(self, **pars):
         super().__init__(**pars)
@@ -211,7 +202,17 @@ class ClassicFiniteSWP3D(SWP3D):
     def get_SSH(
         cls, i: int, r: float, s1: float | int, s2: float | int, **params
     ) -> Self:
-        """ """
+        """Create an SSH-type chain with alternating spacings s1, s2.
+
+        Args:
+            i: Number of unit cells on each side of the central defect resonator.
+            r: Resonator radius (uniform).
+            s1: First spacing between resonator surfaces.
+            s2: Second spacing between resonator surfaces.
+
+        Returns:
+            ClassicFiniteSWP3D with 4*i + 1 resonators along the z-axis.
+        """
         if i < 1:
             raise ValueError("i must be a positive integer")
         if s1 <= 0 or s2 <= 0:
@@ -410,6 +411,7 @@ class ClassicFiniteSWP3D(SWP3D):
         return np.real(C)
 
     def estimate_capacitance_computation_time(self):
+        """Estimate wall-clock seconds for a brute-force capacitance computation (empirical fit)."""
         coeffs = np.array([5.85838395e-05, -1.30743899e-02,  1.07448534e+00])
         return np.polyval(coeffs, self.N)
 
@@ -422,6 +424,20 @@ class ClassicFiniteSWP3D(SWP3D):
             N_jobs=12,
             verbose=False,
     ) -> np.ndarray:
+        """Compute the N x N capacitance matrix.
+
+        Args:
+            N_multipole: Multipole truncation order (1 = monopole, 2 = dipole).
+            method: 'fmm' (fast multipole, N_multipole <= 2), 'colinear' (brute-force, chain on z-axis),
+                or 'general' (brute-force, arbitrary geometry).
+            k0: Wavenumber for the single-layer potential.
+            eps: FMM tolerance (only used with method='fmm').
+            N_jobs: Number of parallel jobs for FMM.
+            verbose: Print caching information.
+
+        Returns:
+            Real N x N capacitance matrix.
+        """
         parameters = {
             "N_multipole": N_multipole,
             "method": method,
@@ -440,7 +456,8 @@ class ClassicFiniteSWP3D(SWP3D):
                 C = self._compute_capactance_matrix_classical(
                     N_multipole=N_multipole, colinear=False, k0=k0)
             elif method == 'fmm':
-                assert N_multipole <= 2, "FMM method only supports up to dipole (N_multipole=2)"
+                if N_multipole > 2:
+                    raise ValueError("FMM method only supports up to dipole (N_multipole=2)")
                 dipole = (N_multipole == 2)
                 C = fmm.compute_capacitance_matrix_accelerated(
                     self.centers, self.radii, eps=eps, dipole=dipole, n_jobs=N_jobs, verbose=verbose

--- a/Subwavelength3D/classic_periodic.py
+++ b/Subwavelength3D/classic_periodic.py
@@ -20,13 +20,11 @@ import numpy as np
 import scipy as sci
 
 from mpmath import polylog
-from mpmath import mp
 from Subwavelength3D.swp import SWP3D
 
-from typing import Literal, Callable, Tuple, List, Dict
-from typing_extensions import override
+from typing import Literal
 
-from scipy.special import spherical_jn, hankel1, sph_harm
+from scipy.special import spherical_jn, hankel1
 from sympy.physics.wigner import wigner_3j
 
 from math import factorial

--- a/Subwavelength3D/fmm.py
+++ b/Subwavelength3D/fmm.py
@@ -1,11 +1,10 @@
-from scipy.sparse.linalg import LinearOperator, cg, gmres, minres, bicg, bicgstab, lgmres
+"""Fast Multipole Method acceleration for 3D capacitance matrix computation."""
+
+from scipy.sparse.linalg import LinearOperator, cg, gmres
 import numpy as np
 import fmm3dpy as fmm
 
-from scipy.special import spherical_jn, hankel1, sph_harm
-from sympy.physics.wigner import wigner_3j
-
-from functools import cache
+from scipy.special import hankel1
 
 from joblib import Parallel, delayed, parallel_config
 
@@ -23,6 +22,18 @@ def _insulate(f):
 
 
 def get_FMM_operator(centers, radii, eps=1e-3, dipole=False, return_diag=False) -> LinearOperator:
+    """Build an FMM-accelerated single-layer potential operator.
+
+    Args:
+        centers: Resonator centres, shape (N, 3).
+        radii: Resonator radii, shape (N,).
+        eps: FMM tolerance.
+        dipole: Include dipole terms (N_multipole=2).
+        return_diag: Also return the diagonal self-interaction vector.
+
+    Returns:
+        LinearOperator (N x N or 4N x 4N), optionally with diagonal vector.
+    """
     N = centers.shape[0]
 
     if not dipole:
@@ -71,16 +82,10 @@ def get_FMM_operator(centers, radii, eps=1e-3, dipole=False, return_diag=False) 
             return LinearOperator((4*N, 4*N), matvec=matvec, dtype=float), self_interactions
         return LinearOperator((4*N, 4*N), matvec=matvec, dtype=float)
 
-    # def matmul(X: np.ndarray):
-    #     # X is a matrix of shape (N, K) with each column corresponding to a different source arrangement
-    #     K = X.shape[1]
-    #     out = fmm.hfmm3d(eps=eps, zk=1e-9, sources=centers.T,
-    #                      charges=X.T, targets=centers.T, pgt=1, nd=K)
-    #     Y = out.pottarg.T  # (N, K)
-    #     return -4*np.pi*out.pottarg + self_interactions*X
 
 
 def operator_to_matrix(F):
+    """Convert a LinearOperator to a dense matrix by probing with unit vectors."""
     M = F.shape[0]
     S = np.zeros((M, M), dtype=float)
     for j in range(M):
@@ -92,6 +97,7 @@ def operator_to_matrix(F):
 
 
 def compute_capacitance_matrix(centers, radii, eps=1e-3, dipole=False):
+    """Compute the capacitance matrix via GMRES solves on the FMM operator (serial)."""
     N = centers.shape[0]
     S = get_FMM_operator(centers, radii, eps=eps, dipole=dipole)
 
@@ -118,7 +124,7 @@ def compute_capacitance_matrix(centers, radii, eps=1e-3, dipole=False):
     return C
 
 
-def compute_capacitance_matrix_accelerated(centers, radii, eps=1e-3, dipole=False, n_jobs=12, verbose=False):
+def compute_capacitance_matrix_accelerated(centers, radii, eps=1e-3, dipole=False, n_jobs=-1, verbose=False):
     """Fast capacitance matrix calculation using SciPy **CG**, Jacobi PC, and **joblib** parallel RHS.
 
     - Forms SPD system 	Tilde{S} = S*C (C = diag(1/r^2), repeated for dipoles)

--- a/Subwavelength3D/nonreciprocal.py
+++ b/Subwavelength3D/nonreciprocal.py
@@ -16,11 +16,8 @@ asymmetry Ĉ(−α) ≠ Ĉ(α) needed for the skin effect.
 import numpy as np
 import scipy as sci
 
-from Subwavelength3D.classic_finite import ClassicFiniteSWP3D, flat_index
-from Subwavelength3D.classic_periodic import (
-    ClassicPeriodicFWP3D,
-    get_indicator_function_spherical_harmonics_expansion,
-)
+from Subwavelength3D.classic_finite import ClassicFiniteSWP3D
+from Subwavelength3D.classic_periodic import ClassicPeriodicFWP3D
 import Utils.utils_general as utils
 
 from typing import Literal, Tuple

--- a/Subwavelength3D/swp.py
+++ b/Subwavelength3D/swp.py
@@ -1,3 +1,5 @@
+"""Base class for three-dimensional subwavelength resonator systems."""
+
 import numpy as np
 
 import copy

--- a/Utils/plots_exploration.py
+++ b/Utils/plots_exploration.py
@@ -1,3 +1,5 @@
+"""Visualization utilities for spectra, eigenvectors, and band structures."""
+
 import numpy as np
 import scipy as sci
 
@@ -11,15 +13,14 @@ import matplotlib.cm as cm
 
 from Utils.settings import settings as settings
 
-from Utils.utils_general import *
+from Utils.utils_general import sort_by_eva_abs
 import Utils.utils_propagation as utils_propagation
 
 import Subwavelength1D.swp as swp
 import Subwavelength1D.classic as classic
 import Subwavelength3D.classic_finite as classic_finite_3D
 import Subwavelength1D.disordered as disordered
-from Subwavelength1D.metaatom import *
-from Subwavelength1D.quasiperiodic import *
+from Subwavelength1D.disordered import DisorderedClassicFiniteSWP1D
 
 from typing import Literal, Callable, Tuple, Self, List
 from typing_extensions import override
@@ -28,8 +29,6 @@ import copy
 from tqdm import tqdm
 
 
-from itertools import product
-from collections import deque
 plt.rcParams.update(settings.matplotlib_params)
 
 
@@ -149,7 +148,6 @@ def visualize_spectrum_with_blockcolors(sp: DisorderedClassicFiniteSWP1D, j, sem
     axes[0].plot(D_cut, 'k.')
     j_cut = len(D_cut) - j
     axes[0].plot(j_cut, D_cut[j_cut], 'ro')
-    print("Lambda:", D_cut[j_cut])
 
     color_list = ["blue", "red", "green"]
     cc = [

--- a/Utils/settings.py
+++ b/Utils/settings.py
@@ -1,3 +1,5 @@
+"""Shared matplotlib settings and figure size constants."""
+
 from dataclasses import dataclass
 
 

--- a/Utils/tools.py
+++ b/Utils/tools.py
@@ -1,3 +1,5 @@
+"""Floquet-Bloch transform, generalised Brillouin zone, and Laurent polynomial utilities."""
+
 import numpy as np
 from typing import Tuple
 

--- a/Utils/utils_general.py
+++ b/Utils/utils_general.py
@@ -1,4 +1,7 @@
+"""General utilities: eigenvalue sorting, root-finding, and eigenvector tracking."""
+
 from functools import wraps
+import warnings
 import numpy as np
 
 import matplotlib.pyplot as plt
@@ -70,7 +73,7 @@ def mullers_method(f, x0, x1, x2, tol=1e-7, max_iter=100):
 
         x0, x1, x2 = x1, x2, p
 
-    print("Muller's method did not converge")
+    warnings.warn("Muller's method did not converge")
     return p
 
 
@@ -202,12 +205,12 @@ class EigenvectorPathTracker:
     """
 
     def __init__(self, initial_sorting_method="eva_real"):
-        self.inital_sorting_method = initial_sorting_method
+        self.initial_sorting_method = initial_sorting_method
         self.D = None
         self.S = None
 
     def _initial(self, D: np.array, S: np.array):
-        D, S = sort_by_method(D, S, self.inital_sorting_method)
+        D, S = sort_by_method(D, S, self.initial_sorting_method)
         self.D, self.S = D.copy(), S.copy()
         return D, S
 

--- a/Utils/utils_propagation.py
+++ b/Utils/utils_propagation.py
@@ -1,3 +1,5 @@
+"""Propagation matrices and Q-matrices for 1D resonator systems."""
+
 import numpy as np
 from typing import Literal, Callable, Tuple, Self, List
 import matplotlib.pyplot as plt
@@ -109,10 +111,6 @@ def propagation_matrix_single(
         M21 = -z * cos_o * sin_i / (vi * delta) - z * cos_i * sin_o / vo
         M22 = cos_i * cos_o - (vi * delta * sin_i * sin_o) / vo
 
-        ckl = np.cos(z * l)
-        skl = np.sin(z * l)
-        cks = np.cos(z * s)
-        sks = np.sin(z * s)
         return np.array([[M11, M12], [M21, M22]])
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,9 @@ contourpy==1.2.1
 cycler==0.12.1
 debugpy==1.8.1
 decorator==5.1.1
+epsteinlib
 executing==2.0.1
-fmm3dpy @ file:///Users/auhlmann/Polybox/PhD/Coding/FMM3D/python
+# fmm3dpy: install from source, see README.adoc for instructions
 fonttools==4.51.0
 idna==3.10
 iniconfig==2.1.0


### PR DESCRIPTION
## Summary

- Fixed all bugs identified in code review (B1–B9): typo in `self.k_in/k_out`, debug `print(M)`, wrong error messages, function name typo, attribute name typo, dead code in propagation matrix, `assert` → `raise ValueError`, `print` → `warnings.warn`
- Added consistent module-level docstrings to all 22 source files
- Added class and method docstrings to previously undocumented public API (ClassicFiniteSWP1D, ClassicFiniteSWP3D, M_matrix classes, exceptional_point, and key methods)
- Removed unused imports across 6 files (classic_finite, classic_periodic, nonreciprocal, fmm, swp, plots_exploration)
- Replaced star imports in `plots_exploration.py` with explicit imports
- Updated `__init__.py` files with public API exports for both Subwavelength1D and Subwavelength3D
- Fixed `requirements.txt`: replaced hardcoded local FMM path with install comment, added `epsteinlib`
- Updated `README.adoc` to v3.0: updated version string, added new files to project tree, added Optional Dependencies section for FMM and Epstein zeta
- Removed dead commented-out code in `fmm.py`, changed `n_jobs=12` → `n_jobs=-1`

## Test plan

- [x] Run full test suite: `pytest tests/ -v`
- [x] Verify all imports succeed: `python -c "import Subwavelength1D.classic; import Subwavelength3D.classic_finite; ..."`
- [x] Confirm no new test failures (5 pre-existing failures in test_3D_finite and test_3D_periodic are unrelated to this PR)
